### PR TITLE
Allow Express 3 route middleware

### DIFF
--- a/express3.d.ts
+++ b/express3.d.ts
@@ -40,13 +40,13 @@ declare module "express3" {
         param(callback: (req: Request, res: Response, next, id) => void);
         param(name: String, callback: (req: Request, res: Response, next, id) => void);
 
-        get(path:String, ...callbacks: { (...args: any[]): void; }[] );
-        post(path:String, ...callbacks: { (...args: any[]): void; }[] );
-        all(path:String, ...callbacks: { (...args: any[]): void; }[] );
+        get(path:String, ...callbacks: Function[] );
+        post(path:String, ...callbacks: Function[] );
+        all(path:String, ...callbacks: Function[] );
 
-        get(path:RegExp, ...callbacks: { (...args: any[]): void; }[] );
-        post(path:RegExp, ...callbacks: { (...args: any[]): void; }[] );
-        all(path:RegExp, ...callbacks: { (...args: any[]): void; }[] );
+        get(path:RegExp, ...callbacks: Function[] );
+        post(path:RegExp, ...callbacks: Function[] );
+        all(path:RegExp, ...callbacks: Function[] );
 
         locals: any;
 


### PR DESCRIPTION
Express 3 routes are often in this format, with any number of middleware functions before the actual request handler:

```
app.get('/', middlewareOne, middlewareTwo, requestHandler)
```

This wasn't allowed by the old module definition. Varargs are only allowed at the end of a parameter list so I've changed it to a list of functions that can have any arguments. There's less type checking in these route calls as a result, but worth it to be able to use route middleware.
