### PR TITLE
Added basic support for nconf

### DIFF
--- a/nconf.d.ts
+++ b/nconf.d.ts
@@ -30,11 +30,10 @@
     export function path(key: any): any[];
     export function loadFiles(files: any, callback?: ICallbackFunction);
     export function loadFilesSync(files: any, callback?: ICallbackFunction);
-    
-    export enum formats
-    {
-       json,
-       ini
+
+    export enum formats {
+        json,
+        ini
     }
 
     export interface IOptions {
@@ -45,6 +44,7 @@
         file?: string;
         dir?: string;
         search?: bool;
+        json_spacing?: number;
     }
 
 
@@ -82,8 +82,11 @@
 
 
     export interface IStore {
+        type: string;
         get (key: string): any;
         set (key: string, value: any): bool;
-    }
-
+        clear(key: string): bool;
+        merge(key: string, value: any): bool;
+        reset(callback?: ICallbackFunction): bool
+        };
 }


### PR DESCRIPTION
Hi, I have added the basic ambient definition for nconf.

This leaves a few of the parts untyped (e.g. the stores and sources parts of the provider class) but it should cover the majority of people who want to use nconf rather than extending it.
