### PR TITLE
Replace node.js with the Microsoft one for typescript 0.9

### DIFF
--- a/node.d.ts
+++ b/node.d.ts
@@ -12,17 +12,6 @@
 declare var process: NodeProcess;
 declare var global: any;
 
-declare var console: {
-    log(...data: any[]): void;
-    info(...data: any[]): void;
-    error(...data: any[]): void;
-    warn(...data: any[]): void;
-    dir(obj: any): void;
-    timeEnd(label: string): void;
-    trace(label: string): void;
-    assert(expression: any, ...message: string[]): void;
-}
-
 declare var __filename: string;
 declare var __dirname: string;
 
@@ -43,7 +32,7 @@ declare var module: {
     require(id: string): any;
     id: string;
     filename: string;
-    loaded: bool;
+    loaded: boolean;
     parent: any;
     children: any[];
 }
@@ -55,7 +44,7 @@ declare var SlowBuffer: {
     new (size: number): NodeBuffer;
     new (array: any[]): NodeBuffer;
     prototype: NodeBuffer;
-    isBuffer(obj: any): bool;
+    isBuffer(obj: any): boolean;
     byteLength(string: string, encoding?: string): number;
     concat(list: NodeBuffer[], totalLength?: number): NodeBuffer;
 };
@@ -64,7 +53,7 @@ declare var Buffer: {
     new (size: number): NodeBuffer;
     new (array: any[]): NodeBuffer;
     prototype: NodeBuffer;
-    isBuffer(obj: any): bool;
+    isBuffer(obj: any): boolean;
     byteLength(string: string, encoding?: string): number;
     concat(list: NodeBuffer[], totalLength?: number): NodeBuffer;
 }
@@ -75,22 +64,21 @@ declare var Buffer: {
 *                                               *
 ************************************************/
 
-interface EventEmitter {
+declare class EventEmitter {
     addListener(event: string, listener: Function);
     on(event: string, listener: Function);
     once(event: string, listener: Function): void;
     removeListener(event: string, listener: Function): void;
-    removeAllListeners(event: string): void;
+    removeAllListener(event: string): void;
     setMaxListeners(n: number): void;
     listeners(event: string): { Function; }[];
-    //emit(event: string, arg1?: any, arg2?: any): void;
-	emit(event: string, ...args: any[]): void;
+    emit(event: string, arg1?: any, arg2?: any): void;
 }
 
-interface WritableStream extends EventEmitter {
-    writable: bool;
-    write(str: string, encoding?: string, fd?: string): bool;
-    write(buffer: NodeBuffer): bool;
+declare class WritableStream extends EventEmitter {
+    writable: boolean;
+    write(str: string, encoding?: string, fd?: string): boolean;
+    write(buffer: NodeBuffer): boolean;
     end(): void;
     end(str: string, enconding: string): void;
     end(buffer: NodeBuffer): void;
@@ -98,16 +86,16 @@ interface WritableStream extends EventEmitter {
     destroySoon(): void;
 }
 
-interface ReadableStream extends EventEmitter {
-    readable: bool;
+declare class ReadableStream extends EventEmitter {
+    readable: boolean;
     setEncoding(encoding: string): void;
     pause(): void;
     resume(): void;
     destroy(): void;
-    pipe(destination: WritableStream, options?: { end?: bool; }): void;
+    pipe(destination: WritableStream, options?: { end?: boolean; }): void;
 }
 
-interface NodeProcess extends EventEmitter {
+declare class NodeProcess extends EventEmitter {
     stdout: WritableStream;
     stderr: WritableStream;
     stdin: ReadableStream;
@@ -115,7 +103,7 @@ interface NodeProcess extends EventEmitter {
     execPath: string;
     abort(): void;
     chdir(directory: string): void;
-    cwd(): void;
+    cwd(): string;
     env: any;
     exit(code?: number): void;
     getgid(): number;
@@ -135,18 +123,18 @@ interface NodeProcess extends EventEmitter {
         variables: {
         clang: number;
         host_arch: string;
-        node_install_npm: bool;
-        node_install_waf: bool;
+        node_install_npm: boolean;
+        node_install_waf: boolean;
         node_prefix: string;
-        node_shared_openssl: bool;
-        node_shared_v8: bool;
-        node_shared_zlib: bool;
-        node_use_dtrace: bool;
-        node_use_etw: bool;
-        node_use_openssl: bool;
+        node_shared_openssl: boolean;
+        node_shared_v8: boolean;
+        node_shared_zlib: boolean;
+        node_use_dtrace: boolean;
+        node_use_etw: boolean;
+        node_use_openssl: boolean;
         target_arch: string;
         v8_no_strict_aliasing: number;
-        v8_use_snapshot: bool;
+        v8_use_snapshot: boolean;
         visibility: string;
     };
     };
@@ -170,34 +158,34 @@ interface NodeBuffer {
     length: number;
     copy(targetBuffer: NodeBuffer, targetStart?: number, sourceStart?: number, sourceEnd?: number): void;
     slice(start?: number, end?: number): NodeBuffer;
-    readUInt8(offset: number, noAsset?: bool): number;
-    readUInt16LE(offset: number, noAssert?: bool): number;
-    readUInt16BE(offset: number, noAssert?: bool): number;
-    readUInt32LE(offset: number, noAssert?: bool): number;
-    readUInt32BE(offset: number, noAssert?: bool): number;
-    readInt8(offset: number, noAssert?: bool): number;
-    readInt16LE(offset: number, noAssert?: bool): number;
-    readInt16BE(offset: number, noAssert?: bool): number;
-    readInt32LE(offset: number, noAssert?: bool): number;
-    readInt32BE(offset: number, noAssert?: bool): number;
-    readFloatLE(offset: number, noAssert?: bool): number;
-    readFloatBE(offset: number, noAssert?: bool): number;
-    readDoubleLE(offset: number, noAssert?: bool): number;
-    readDoubleBE(offset: number, noAssert?: bool): number;
-    writeUInt8(value: number, offset: number, noAssert?: bool): void;
-    writeUInt16LE(value: number, offset: number, noAssert?: bool): void;
-    writeUInt16BE(value: number, offset: number, noAssert?: bool): void;
-    writeUInt32LE(value: number, offset: number, noAssert?: bool): void;
-    writeUInt32BE(value: number, offset: number, noAssert?: bool): void;
-    writeInt8(value: number, offset: number, noAssert?: bool): void;
-    writeInt16LE(value: number, offset: number, noAssert?: bool): void;
-    writeInt16BE(value: number, offset: number, noAssert?: bool): void;
-    writeInt32LE(value: number, offset: number, noAssert?: bool): void;
-    writeInt32BE(value: number, offset: number, noAssert?: bool): void;
-    writeFloatLE(value: number, offset: number, noAssert?: bool): void;
-    writeFloatBE(value: number, offset: number, noAssert?: bool): void;
-    writeDoubleLE(value: number, offset: number, noAssert?: bool): void;
-    writeDoubleBE(value: number, offset: number, noAssert?: bool): void;
+    readUInt8(offset: number, noAsset?: boolean): number;
+    readUInt16LE(offset: number, noAssert?: boolean): number;
+    readUInt16BE(offset: number, noAssert?: boolean): number;
+    readUInt32LE(offset: number, noAssert?: boolean): number;
+    readUInt32BE(offset: number, noAssert?: boolean): number;
+    readInt8(offset: number, noAssert?: boolean): number;
+    readInt16LE(offset: number, noAssert?: boolean): number;
+    readInt16BE(offset: number, noAssert?: boolean): number;
+    readInt32LE(offset: number, noAssert?: boolean): number;
+    readInt32BE(offset: number, noAssert?: boolean): number;
+    readFloatLE(offset: number, noAssert?: boolean): number;
+    readFloatBE(offset: number, noAssert?: boolean): number;
+    readDoubleLE(offset: number, noAssert?: boolean): number;
+    readDoubleBE(offset: number, noAssert?: boolean): number;
+    writeUInt8(value: number, offset: number, noAssert?: boolean): void;
+    writeUInt16LE(value: number, offset: number, noAssert?: boolean): void;
+    writeUInt16BE(value: number, offset: number, noAssert?: boolean): void;
+    writeUInt32LE(value: number, offset: number, noAssert?: boolean): void;
+    writeUInt32BE(value: number, offset: number, noAssert?: boolean): void;
+    writeInt8(value: number, offset: number, noAssert?: boolean): void;
+    writeInt16LE(value: number, offset: number, noAssert?: boolean): void;
+    writeInt16BE(value: number, offset: number, noAssert?: boolean): void;
+    writeInt32LE(value: number, offset: number, noAssert?: boolean): void;
+    writeInt32BE(value: number, offset: number, noAssert?: boolean): void;
+    writeFloatLE(value: number, offset: number, noAssert?: boolean): void;
+    writeFloatBE(value: number, offset: number, noAssert?: boolean): void;
+    writeDoubleLE(value: number, offset: number, noAssert?: boolean): void;
+    writeDoubleBE(value: number, offset: number, noAssert?: boolean): void;
     fill(value: any, offset?: number, end?: number): void;
     INSPECT_MAX_BYTES: number;
 }
@@ -215,7 +203,7 @@ declare module "querystring" {
 }
 
 declare module "events" {
-    export interface NodeEventEmitter {
+    export class EventEmitter {
         addListener(event: string, listener: Function);
         on(event: string, listener: Function): any;
         once(event: string, listener: Function): void;
@@ -225,27 +213,24 @@ declare module "events" {
         listeners(event: string): { Function; }[];
         emit(event: string, arg1?: any, arg2?: any): void;
     }
-
-    export var EventEmitter: NodeEventEmitter;
 }
 
 declare module "http" {
-    import events = module("events");
-    import net = module("net");
-    import stream = module("stream");
+    import events = require("events");
+    import net = require("net");
+    import stream = require("stream");
 
-    export interface Server extends events.NodeEventEmitter {
+    export class Server extends events.EventEmitter {
         listen(port: number, hostname?: string, backlog?: number, callback?: Function): void;
-		listen(port: number, hostname?: number, callback?: Function): void;
         listen(path: string, callback?: Function): void;
         listen(handle: any, listeningListener?: Function): void;
         close(cb?: any): void;
         maxHeadersCount: number;
     }
-    export interface ServerRequest extends events.NodeEventEmitter, stream.ReadableStream {
+    export class ServerRequest extends stream.ReadableStream {
         method: string;
         url: string;
-        headers: any;
+        headers: string;
         trailers: string;
         httpVersion: string;
         setEncoding(encoding?: string): void;
@@ -253,36 +238,36 @@ declare module "http" {
         resume(): void;
         connection: net.NodeSocket;
     }
-    export interface ServerResponse extends events.NodeEventEmitter, stream.WritableStream {
+    export class ServerResponse extends stream.WritableStream {
         // Extended base methods
-        write(str: string, encoding?: string, fd?: string): bool;
-        write(buffer: NodeBuffer): bool;
+        write(str: string, encoding?: string, fd?: string): boolean;
+        write(buffer: NodeBuffer): boolean;
 
         writeContinue(): void;
         writeHead(statusCode: number, reasonPhrase?: string, headers?: any): void;
         writeHead(statusCode: number, headers?: any): void;
         statusCode: number;
         setHeader(name: string, value: string): void;
-        sendDate: bool;
+        sendDate: boolean;
         getHeader(name: string): string;
         removeHeader(name: string): void;
         write(chunk: any, encoding?: string): any;
         addTrailers(headers: any): void;
         end(data?: any, encoding?: string): void;
     }
-    export interface ClientRequest extends events.NodeEventEmitter, stream.WritableStream {
+    export class ClientRequest extends stream.WritableStream {
         // Extended base methods
-        write(str: string, encoding?: string, fd?: string): bool;
-        write(buffer: NodeBuffer): bool;
+        write(str: string, encoding?: string, fd?: string): boolean;
+        write(buffer: NodeBuffer): boolean;
 
         write(chunk: any, encoding?: string): void;
         end(data?: any, encoding?: string): void;
         abort(): void;
         setTimeout(timeout: number, callback?: Function): void;
         setNoDelay(noDelay?: Function): void;
-        setSocketKeepAlive(enable?: bool, initialDelay?: number): void;
+        setSocketKeepAlive(enable?: boolean, initialDelay?: number): void;
     }
-    export interface ClientResponse extends events.NodeEventEmitter, stream.ReadableStream {
+    export class ClientResponse extends stream.ReadableStream {
         statusCode: number;
         httpVersion: string;
         headers: any;
@@ -296,23 +281,23 @@ declare module "http" {
     export var STATUS_CODES;
     export function createServer(requestListener?: (request: ServerRequest, response: ServerResponse) =>void ): Server;
     export function createClient(port?: number, host?: string): any;
-    export function request(options: any, callback?: (res: ClientResponse) => void): ClientRequest;
-    export function get (options: any, callback?: (res: ClientResponse) => void): ClientRequest;
+    export function request(options: any, callback?: Function): ClientRequest;
+    export function get(options: any, callback?: Function): ClientRequest;
     export var globalAgent: Agent;
 }
 
 declare module "cluster" {
-    import child_process = module("child_process");
+    import child_process = require("child_process");
 
     export interface ClusterSettings {
         exec: string;
         args: string[];
-        silent: bool;
+        silent: boolean;
     }
     export interface Worker {
         id: string;
-        process: child_process;
-        suicide: bool;
+        process: child_process.ChildProcess;
+        suicide: boolean;
         send(message: any, sendHandle?: any): void;
         destroy(): void;
         disconnect(): void;
@@ -320,8 +305,8 @@ declare module "cluster" {
 
 
     export var settings: ClusterSettings;
-    export var isMaster: bool;
-    export var isWorker: bool;
+    export var isMaster: boolean;
+    export var isWorker: boolean;
     export function setupMaster(settings?: ClusterSettings): void;
     export function fork(env?: any): Worker;
     export function disconnect(callback?: Function): void;
@@ -339,16 +324,16 @@ declare module "cluster" {
 }
 
 declare module "zlib" {
-    import stream = module("stream");
+    import stream = require("stream");
     export interface ZlibOptions { chunkSize?: number; windowBits?: number; level?: number; memLevel?: number; strategy?: number; dictionary?: any; }
 
-    export interface Gzip extends stream.ReadWriteStream { }
-    export interface Gunzip extends stream.ReadWriteStream { }
-    export interface Deflate extends stream.ReadWriteStream { }
-    export interface Inflate extends stream.ReadWriteStream { }
-    export interface DeflateRaw extends stream.ReadWriteStream { }
-    export interface InflateRaw extends stream.ReadWriteStream { }
-    export interface Unzip extends stream.ReadWriteStream { }
+    export class Gzip extends stream.ReadWriteStream { }
+    export class Gunzip extends stream.ReadWriteStream { }
+    export class Deflate extends stream.ReadWriteStream { }
+    export class Inflate extends stream.ReadWriteStream { }
+    export class DeflateRaw extends stream.ReadWriteStream { }
+    export class InflateRaw extends stream.ReadWriteStream { }
+    export class Unzip extends stream.ReadWriteStream { }
 
     export function createGzip(options: ZlibOptions): Gzip;
     export function createGunzip(options: ZlibOptions): Gunzip;
@@ -417,9 +402,9 @@ declare module "os" {
 }
 
 declare module "https" {
-    import tls = module("tls");
-    import events = module("events");
-    import http = module("http");
+    import tls = require("tls");
+    import events = require("events");
+    import http = require("http");
 
     export interface ServerOptions {
         pfx?: any;
@@ -429,9 +414,9 @@ declare module "https" {
         ca?: any;
         crl?: any;
         ciphers?: string;
-        honorCipherOrder?: bool;
-        requestCert?: bool;
-        rejectUnauthorized?: bool;
+        honorCipherOrder?: boolean;
+        requestCert?: boolean;
+        rejectUnauthorized?: boolean;
         NPNProtocols?: any;
         SNICallback?: (servername: string) => any;
     }
@@ -451,7 +436,7 @@ declare module "https" {
         cert?: any;
         ca?: any;
         ciphers?: string;
-        rejectUnauthorized?: bool;
+        rejectUnauthorized?: boolean;
     }
 
     export interface NodeAgent {
@@ -462,10 +447,10 @@ declare module "https" {
     export var Agent: {
         new (options?: RequestOptions): NodeAgent;
     };
-    export interface Server extends tls.Server { }
+    export class Server extends tls.Server { }
     export function createServer(options: ServerOptions, requestListener?: Function): Server;
-    export function request(options: RequestOptions, callback?: (res: events.NodeEventEmitter) =>void ): http.ClientRequest;
-    export function get(options: RequestOptions, callback?: (res: events.NodeEventEmitter) =>void ): http.ClientRequest;
+    export function request(options: RequestOptions, callback?: (res: events.EventEmitter) =>void ): http.ClientRequest;
+    export function get(options: RequestOptions, callback?: (res: events.EventEmitter) =>void ): http.ClientRequest;
     export var globalAgent: NodeAgent;
 }
 
@@ -475,7 +460,7 @@ declare module "punycode" {
     export function toUnicode(domain: string): string;
     export function toASCII(domain: string): string;
     export var ucs2: ucs2;
-    interface ucs2 {
+    export interface ucs2 {
         decode(string: string): string;
         encode(codePoints: number[]): string;
     }
@@ -483,30 +468,30 @@ declare module "punycode" {
 }
 
 declare module "repl" {
-    import stream = module("stream");
-    import events = module("events");
+    import stream = require("stream");
+    import events = require("events");
 
     export interface ReplOptions {
         prompt?: string;
         input?: stream.ReadableStream;
         output?: stream.WritableStream;
-        terminal?: bool;
+        terminal?: boolean;
         eval?: Function;
-        useColors?: bool;
-        useGlobal?: bool;
-        ignoreUndefined?: bool;
+        useColors?: boolean;
+        useGlobal?: boolean;
+        ignoreUndefined?: boolean;
         writer?: Function;
     }
-    export function start(options: ReplOptions): events.NodeEventEmitter;
+    export function start(options: ReplOptions): events.EventEmitter;
 }
 
 declare module "readline" {
-    import events = module("events");
-    import stream = module("stream");
+    import events = require("events");
+    import stream = require("stream");
 
-    export interface ReadLine extends events.NodeEventEmitter {
+    export class ReadLine extends events.EventEmitter {
         setPrompt(prompt: string, length: number): void;
-        prompt(preserveCursor?: bool): void;
+        prompt(preserveCursor?: boolean): void;
         question(query: string, callback: Function): void;
         pause(): void;
         resume(): void;
@@ -517,7 +502,7 @@ declare module "readline" {
         input: stream.ReadableStream;
         output: stream.WritableStream;
         completer?: Function;
-        terminal?: bool;
+        terminal?: boolean;
     }
     export function createInterface(options: ReadLineOptions): ReadLine;
 }
@@ -536,10 +521,10 @@ declare module "vm" {
 }
 
 declare module "child_process" {
-    import events = module("events");
-    import stream = module("stream");
+    import events = require("events");
+    import stream = require("stream");
 
-    export interface ChildProcess extends events.NodeEventEmitter {
+    export class ChildProcess extends events.EventEmitter {
         stdin: stream.WritableStream;
         stdout: stream.ReadableStream;
         stderr: stream.ReadableStream;
@@ -554,7 +539,7 @@ declare module "child_process" {
         stdio?: any;
         custom?: any;
         env?: any;
-        detached?: bool;
+        detached?: boolean;
     }): ChildProcess;
     export function exec(command: string, options: {
         cwd?: string;
@@ -595,7 +580,7 @@ declare module "url" {
         pathname?: string;
         search?: string;
         query?: string;
-        slashes?: bool;
+        slashes?: boolean;
         hash?: string;
     }
 
@@ -620,12 +605,12 @@ declare module "dns" {
 }
 
 declare module "net" {
-    import stream = module("stream");
+    import stream = require("stream");
 
-    export interface NodeSocket extends stream.ReadWriteStream {
+    export class NodeSocket extends stream.ReadWriteStream {
         // Extended base methods
-        write(str: string, encoding?: string, fd?: string): bool;
-        write(buffer: NodeBuffer): bool;
+        write(str: string, encoding?: string, fd?: string): boolean;
+        write(buffer: NodeBuffer): boolean;
 
         connect(port: number, host?: string, connectionListener?: Function): void;
         connect(path: string, connectionListener?: Function): void;
@@ -637,8 +622,8 @@ declare module "net" {
         pause(): void;
         resume(): void;
         setTimeout(timeout: number, callback?: Function); void;
-        setNoDelay(noDelay?: bool): void;
-        setKeepAlive(enable?: bool, initialDelay?: number): void;
+        setNoDelay(noDelay?: boolean): void;
+        setKeepAlive(enable?: boolean, initialDelay?: number): void;
         address(): { port: number; family: string; address: string; };
         remoteAddress: string;
         remotePort: number;
@@ -647,10 +632,10 @@ declare module "net" {
     }
 
     export var Socket: {
-        new (options?: { fd?: string; type?: string; allowHalfOpen?: bool; }): NodeSocket;
+        new (options?: { fd?: string; type?: string; allowHalfOpen?: boolean; }): NodeSocket;
     };
 
-    export interface Server extends NodeSocket {
+    export class Server extends NodeSocket {
         listen(port: number, host?: string, backlog?: number, listeningListener?: Function): void;
         listen(path: string, listeningListener?: Function): void;
         listen(handle: any, listeningListener?: Function): void;
@@ -660,47 +645,47 @@ declare module "net" {
         connections: number;
     }
     export function createServer(connectionListener?: (socket: NodeSocket) =>void ): Server;
-    export function createServer(options?: { allowHalfOpen?: bool; }, connectionListener?: (socket: NodeSocket) =>void ): Server;
-    export function connect(options: { allowHalfOpen?: bool; }, connectionListener?: Function): void;
+    export function createServer(options?: { allowHalfOpen?: boolean; }, connectionListener?: (socket: NodeSocket) =>void ): Server;
+    export function connect(options: { allowHalfOpen?: boolean; }, connectionListener?: Function): void;
     export function connect(port: number, host?: string, connectionListener?: Function): void;
     export function connect(path: string, connectionListener?: Function): void;
-    export function createConnection(options: { allowHalfOpen?: bool; }, connectionListener?: Function): void;
+    export function createConnection(options: { allowHalfOpen?: boolean; }, connectionListener?: Function): void;
     export function createConnection(port: number, host?: string, connectionListener?: Function): void;
     export function createConnection(path: string, connectionListener?: Function): void;
     export function isIP(input: string): number;
-    export function isIPv4(input: string): bool;
-    export function isIPv6(input: string): bool;
+    export function isIPv4(input: string): boolean;
+    export function isIPv6(input: string): boolean;
 }
 
 declare module "dgram" {
-    import events = module("events");
+    import events = require("events");
 
     export function createSocket(type: string, callback?: Function): Socket;
 
-    interface Socket extends events.NodeEventEmitter {
+    export class Socket extends events.EventEmitter {
         send(buf: NodeBuffer, offset: number, length: number, port: number, address: string, callback?: Function): void;
         bind(port: number, address?: string): void;
         close(): void;
         address: { address: string; family: string; port: number; };
-        setBroadcast(flag: bool): void;
+        setBroadcast(flag: boolean): void;
         setMulticastTTL(ttl: number): void;
-        setMulticastLoopback(flag: bool): void;
+        setMulticastLoopback(flag: boolean): void;
         addMembership(multicastAddress: string, multicastInterface?: string): void;
         dropMembership(multicastAddress: string, multicastInterface?: string): void;
     }
 }
 
 declare module "fs" {
-    import stream = module("stream");
+    import stream = require("stream");
 
-    interface Stats {
-        isFile(): bool;
-        isDirectory(): bool;
-        isBlockDevice(): bool;
-        isCharacterDevice(): bool;
-        isSymbolicLink(): bool;
-        isFIFO(): bool;
-        isSocket(): bool;
+    export interface Stats {
+        isFile(): boolean;
+        isDirectory(): boolean;
+        isBlockDevice(): boolean;
+        isCharacterDevice(): boolean;
+        isSymbolicLink(): boolean;
+        isFIFO(): boolean;
+        isSocket(): boolean;
         dev: number;
         ino: number;
         mode: number;
@@ -716,12 +701,12 @@ declare module "fs" {
         ctime: Date;
     }
 
-    interface FSWatcher {
+    export interface FSWatcher {
         close(): void;
     }
 
-    export interface ReadStream extends stream.ReadableStream { }
-    export interface WriteStream extends stream.WritableStream { }
+    export class ReadStream extends stream.ReadableStream { }
+    export class WriteStream extends stream.WritableStream { }
 
     export function rename(oldPath: string, newPath: string, callback?: Function): void;
     export function renameSync(oldPath: string, newPath: string): void;
@@ -758,12 +743,13 @@ declare module "fs" {
     export function readlink(path: string, callback?: (err: Error, linkString: string) =>any): void;
     export function realpath(path: string, callback?: (err: Error, resolvedPath: string) =>any): void;
     export function realpath(path: string, cache: string, callback: (err: Error, resolvedPath: string) =>any): void;
-    export function realpathSync(path: string, cache?: bool): string;
+    export function realpathSync(path: string, cache?: string): string;
     export function unlink(path: string, callback?: Function): void;
     export function unlinkSync(path: string): void;
     export function rmdir(path: string, callback?: Function): void;
     export function rmdirSync(path: string): void;
-    export function mkdir(path: string, mode?: any, callback?: Function): void;
+    export function mkdir(path: string, mode?: number, callback?: Function): void;
+    export function mkdir(path: string, mode?: string, callback?: Function): void;
     export function mkdirSync(path: string, mode?: number): void;
     export function mkdirSync(path: string, mode?: string): void;
     export function readdir(path: string, callback?: (err: Error, files: string[]) => void): void;
@@ -791,11 +777,11 @@ declare module "fs" {
     export function appendFile(filename: string, data: any, encoding?: string, callback?: Function): void;
     export function appendFileSync(filename: string, data: any, encoding?: string): void;
     export function watchFile(filename: string, listener: { curr: Stats; prev: Stats; }): void;
-    export function watchFile(filename: string, options: { persistent?: bool; interval?: number; }, listener: { curr: Stats; prev: Stats; }): void;
+    export function watchFile(filename: string, options: { persistent?: boolean; interval?: number; }, listener: { curr: Stats; prev: Stats; }): void;
     export function unwatchFile(filename: string, listener?: Stats): void;
-    export function watch(filename: string, options?: { persistent?: bool; }, listener?: (event: string, filename: string) =>any): FSWatcher;
-    export function exists(path: string, callback?: (exists: bool) =>void ): void;
-    export function existsSync(path: string): bool;
+    export function watch(filename: string, options?: { persistent?: boolean; }, listener?: (event: string, filename: string) =>any): FSWatcher;
+    export function exists(path: string, callback?: (exists: boolean) =>void ): void;
+    export function existsSync(path: string): boolean;
     export function createReadStream(path: string, options?: {
         flags?: string;
         encoding?: string;
@@ -813,7 +799,6 @@ declare module "fs" {
 declare module "path" {
     export function normalize(p: string): string;
     export function join(...paths: any[]): string;
-    export function resolve(to: string): string;
     export function resolve(from: string, to: string): string;
     export function resolve(from: string, from2: string, to: string): string;
     export function resolve(from: string, from2: string, from3: string, to: string): string;
@@ -837,12 +822,12 @@ declare module "string_decoder" {
 }
 
 declare module "tls" {
-    import crypto = module("crypto");
-    import net = module("net");
-    import stream = module("stream");
+    import crypto = require("crypto");
+    import net = require("net");
+    import stream = require("stream");
 
-    var CLIENT_RENEG_LIMIT: number;
-    var CLIENT_RENEG_WINDOW: number;
+    export var CLIENT_RENEG_LIMIT: number;
+    export var CLIENT_RENEG_WINDOW: number;
 
     export interface TlsOptions {
         pfx?: any;   //string or buffer
@@ -853,8 +838,8 @@ declare module "tls" {
         crl?: any;   //string or string array
         ciphers?: string;
         honorCipherOrder?: any;
-        requestCert?: bool;
-        rejectUnauthorized?: bool;
+        requestCert?: boolean;
+        rejectUnauthorized?: boolean;
         NPNProtocols?: any;  //array or Buffer;
         SNICallback?: (servername: string) => any;
     }
@@ -868,12 +853,12 @@ declare module "tls" {
         passphrase?: string;
         cert?: any;  //string | Buffer
         ca?: any;    //Array of string | Buffer
-        rejectUnauthorized?: bool;
+        rejectUnauthorized?: boolean;
         NPNProtocols?: any;  //Array of string | Buffer
         servername?: string;
     }
 
-    export interface Server extends net.Server {
+    export class Server extends net.Server {
         // Extended base methods
         listen(port: number, host?: string, backlog?: number, listeningListener?: Function): void;
         listen(path: string, listeningListener?: Function): void;
@@ -891,8 +876,8 @@ declare module "tls" {
         connections: number;
     }
 
-    export interface ClearTextStream extends stream.ReadWriteStream {
-        authorized: bool;
+    export class ClearTextStream extends stream.ReadWriteStream {
+        authorized: boolean;
         authorizationError: Error;
         getPeerCertificate(): any;
         getCipher: {
@@ -917,7 +902,7 @@ declare module "tls" {
     export function connect(options: TlsOptions, secureConnectionListener?: () =>void ): ClearTextStream;
     export function connect(port: number, host?: string, options?: ConnectionOptions, secureConnectListener?: () =>void ): ClearTextStream;
     export function connect(port: number, options?: ConnectionOptions, secureConnectListener?: () =>void ): ClearTextStream;
-    export function createSecurePair(credentials?: crypto.Credentials, isServer?: bool, requestCert?: bool, rejectUnauthorized?: bool): SecurePair;
+    export function createSecurePair(credentials?: crypto.Credentials, isServer?: boolean, requestCert?: boolean, rejectUnauthorized?: boolean): SecurePair;
 }
 
 declare module "crypto" {
@@ -934,41 +919,41 @@ declare module "crypto" {
     export function createCredentials(details: CredentialDetails): Credentials;
     export function createHash(algorithm: string): Hash;
     export function createHmac(algorithm: string, key: string): Hmac;
-    interface Hash {
-        update(data: any, input_encoding?: string): Hash;
+    export interface Hash {
+        update(data: any, input_encoding?: string): void;
         digest(encoding?: string): string;
     }
-    interface Hmac {
-        update(data: any): Hmac;
+    export interface Hmac {
+        update(data: any): void;
         digest(encoding?: string): void;
     }
     export function createCipher(algorithm: string, password: any): Cipher;
     export function createCipheriv(algorithm: string, key: any, iv: any): Cipher;
-    interface Cipher {
+    export interface Cipher {
         update(data: any, input_encoding?: string, output_encoding?: string): string;
         final(output_encoding?: string): string;
-        setAutoPadding(auto_padding: bool): void;
+        setAutoPadding(auto_padding: boolean): void;
+        createDecipher(algorithm: string, password: any): Decipher;
+        createDecipheriv(algorithm: string, key: any, iv: any): Decipher;
     }
-    export function createDecipher(algorithm: string, password: any): Decipher;
-    export function createDecipheriv(algorithm: string, key: any, iv: any): Decipher;
-    interface Decipher {
+    export interface Decipher {
         update(data: any, input_encoding?: string, output_encoding?: string): void;
         final(output_encoding?: string): string;
-        setAutoPadding(auto_padding: bool): void;
+        setAutoPadding(auto_padding: boolean): void;
     }
     export function createSign(algorithm: string): Signer;
-    interface Signer {
+    export interface Signer {
         update(data: any): void;
         sign(private_key: string, output_format: string): string;
     }
     export function createVerify(algorith: string): Verify;
-    interface Verify {
+    export interface Verify {
         update(data: any): void;
-        verify(object: string, signature: string, signature_format?: string): bool;
+        verify(object: string, signature: string, signature_format?: string): boolean;
     }
     export function createDiffieHellman(prime_length: number): DiffieHellman;
     export function createDiffieHellman(prime: number, encoding?: string): DiffieHellman;
-    interface DiffieHellman {
+    export interface DiffieHellman {
         generateKeys(encoding?: string): string;
         computeSecret(other_public_key: string, input_encoding?: string, output_encoding?: string): string;
         getPrime(encoding?: string): string;
@@ -984,12 +969,12 @@ declare module "crypto" {
 }
 
 declare module "stream" {
-    import events = module("events");
+    import events = require("events");
 
-    export interface WritableStream extends events.NodeEventEmitter {
-        writable: bool;
-        write(str: string, encoding?: string, fd?: string): bool;
-        write(buffer: NodeBuffer): bool;
+    export interface WriteStream {
+        writable: boolean;
+        write(str: string, encoding?: string, fd?: string): boolean;
+        write(buffer: NodeBuffer): boolean;
         end(): void;
         end(str: string, enconding: string): void;
         end(buffer: NodeBuffer): void;
@@ -997,16 +982,42 @@ declare module "stream" {
         destroySoon(): void;
     }
 
-    export interface ReadableStream extends events.NodeEventEmitter {
-        readable: bool;
+    export class WritableStream extends events.EventEmitter implements WriteStream {
+        writable: boolean;
+        write(str: string, encoding?: string, fd?: string): boolean;
+        write(buffer: NodeBuffer): boolean;
+        end(): void;
+        end(str: string, enconding: string): void;
+        end(buffer: NodeBuffer): void;
+        destroy(): void;
+        destroySoon(): void;
+    }
+
+    export class ReadableStream extends events.EventEmitter {
+        readable: boolean;
         setEncoding(encoding: string): void;
         pause(): void;
         resume(): void;
         destroy(): void;
-        pipe(destination: WritableStream, options?: { end?: bool; }): void;
+        pipe(destination: WriteStream, options?: { end?: boolean; }): void;
     }
 
-    export interface ReadWriteStream extends ReadableStream, WritableStream { }
+    export class ReadWriteStream extends events.EventEmitter implements WriteStream {
+        readable: boolean;
+        setEncoding(encoding: string): void;
+        pause(): void;
+        resume(): void;
+        pipe(destination: WriteStream, options?: { end?: boolean; }): void;
+
+        writable: boolean;
+        write(str: string, encoding?: string, fd?: string): boolean;
+        write(buffer: NodeBuffer): boolean;
+        end(): void;
+        end(str: string, enconding: string): void;
+        end(buffer: NodeBuffer): void;
+        destroy(): void;
+        destroySoon(): void;
+    }
 }
 
 declare module "util" {
@@ -1016,11 +1027,11 @@ declare module "util" {
     export function puts(...param: any[]): void;
     export function print(...param: any[]): void;
     export function log(string: string): void;
-    export function inspect(object: any, showHidden?: bool, depth?: number, color?: bool): string;
-    export function isArray(object: any): bool;
-    export function isRegExp(object: any): bool;
-    export function isDate(object: any): bool;
-    export function isError(object: any): bool;
+    export function inspect(object: any, showHidden?: boolean, depth?: number, color?: boolean): void;
+    export function isArray(object: any): boolean;
+    export function isRegExp(object: any): boolean;
+    export function isDate(object: any): boolean;
+    export function isError(object: any): boolean;
     export function inherits(constructor: any, superConstructor: any): void;
 }
 
@@ -1040,28 +1051,28 @@ declare module "assert" {
 }
 
 declare module "tty" {
-    import net = module("net");
+    import net = require("net");
 
-    export function isatty(fd: string): bool;
-    export interface ReadStream extends net.NodeSocket {
-        isRaw: bool;
-        setRawMode(mode: bool): void;
+    export function isatty(fd: string): boolean;
+    export class ReadStream extends net.NodeSocket {
+        isRaw: boolean;
+        setRawMode(mode: boolean): void;
     }
-    export interface WriteStream extends net.NodeSocket {
+    export class WriteStream extends net.NodeSocket {
         columns: number;
         rows: number;
     }
 }
 
 declare module "domain" {
-    import events = module("events");
+    import events = require("events");
 
-    export interface Domain extends events.NodeEventEmitter { }
+    export class Domain extends events.EventEmitter { }
 
     export function create(): Domain;
     export function run(fn: Function): void;
-    export function add(emitter: events.NodeEventEmitter): void;
-    export function remove(emitter: events.NodeEventEmitter): void;
+    export function add(emitter: events.EventEmitter): void;
+    export function remove(emitter: events.EventEmitter): void;
     export function bind(cb: (er: Error, data: any) =>any): any;
     export function intercept(cb: (data: any) => any): any;
     export function dispose(): void;


### PR DESCRIPTION
Typscript 0.9 has broken a lot of the definitions.

I have replaced the node.d.ts one with the latest version from the typescript codeplex site. Unfortunately this will revert the changes you have done outside codeplex, so I understand if you want to reject it and work on it further, but for me it is at least a start to be able to migrate to 0.9
