### PR TITLE
adding type for move function in fs-extra module

### DIFF
--- a/fs-extra.d.ts
+++ b/fs-extra.d.ts
@@ -37,6 +37,7 @@ declare module "fs-extra" {
   export function copy(src: string, dest: string, filter?, callback?: Function): void;
   export function createFile(file: string, callback?: Function): void;
   export function mkdirs(dir: string, callback?: Function): void;
+  export function move(src: string, dest: string, filter?, callback?: Function): void;
   export function outputFile(file: string, data, callback?: Function): void;
   export function outputJson(file: string, data, callback?: Function): void;
   export function readJson(file, options?, callback?: Function): void;


### PR DESCRIPTION
The type for "move" function was missed. 
It is very similar to "copy" function, so I used exactly the same type for "move".

https://www.npmjs.com/package/fs-extra#movesrc-dest-options-callback