### PR TITLE
fixes nconf get

### DIFF
--- a/nconf.d.ts
+++ b/nconf.d.ts
@@ -4,7 +4,7 @@
     export var sources: any[];
 
     export function clear(key: string, callback?: ICallbackFunction): any;
-    export function get (key: string, callback?: ICallbackFunction): any;
+    export function get (key?: string, callback?: ICallbackFunction): any;
     export function merge(key: string, value: any, callback?: ICallbackFunction): any;
     export function set (key: string, value: any, callback?: ICallbackFunction): any;
     export function reset(callback?: ICallbackFunction): any;


### PR DESCRIPTION
`nconf.get()` is used to dump the entire configuration and should therefore be optional