### PR TITLE
Update memory-cache.d.ts timeout callback

### DIFF
--- a/memory-cache.d.ts
+++ b/memory-cache.d.ts
@@ -1,5 +1,5 @@
 declare module "memory-cache" {
-    export function put(key: any, value: any, time?: number, timeoutCallback?: (key: any) => void) : void;
+    export function put(key: any, value: any, time?: number, timeoutCallback?: (key: any, value: any) => void) : void;
     export function get(key: any): any;
     export function del(key: any): void;
     export function clear(): void;


### PR DESCRIPTION
Per code at https://github.com/ptarjan/node-cache/blob/master/index.js line 37, the timeout callback takes the value as well as the key. Fixing the definition so it can be passed easily.